### PR TITLE
Fix annotation handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,11 @@ go 1.16
 require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/onsi/ginkgo v1.14.1
-	github.com/onsi/gomega v1.10.2
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,7 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/pkg/istio-aux/constants.go
+++ b/pkg/istio-aux/constants.go
@@ -20,7 +20,10 @@ const IstioAuxLabelName = "io.datastrophic/istio-aux"
 const IstioAuxLabelValue = "enabled"
 
 const IstioPodAnnotationName = "proxy.istio.io/config"
-const IstioPodAnnotationValue = "holdApplicationUntilProxyStarts: true"
+
+var IstioPodAnnotationValue = map[string]interface{}{
+	"holdApplicationUntilProxyStarts": true,
+}
 
 const IstioInjectionLabelName = "istio-injection"
 const IstioInjectionLabelValue = "enabled"

--- a/pkg/istio-aux/util_test.go
+++ b/pkg/istio-aux/util_test.go
@@ -19,24 +19,38 @@ func TestSetAnnotation(t *testing.T) {
 	})
 
 	t.Run("it=merges with existing annotation", func(tt *testing.T) {
-
 		existingAnnotation := map[string]interface{}{
 			"proxyMetadata": map[string]interface{}{
 				"OUTPUT_CERTS": "/etc/istio-output-certs",
 			},
 		}
-
 		objectMeta := &metav1.ObjectMeta{
 			Annotations: map[string]string{
 				IstioPodAnnotationName: toYaml(tt, existingAnnotation),
 			},
 		}
-
 		SetMetadata(objectMeta)
-
 		assert.NotNil(tt, objectMeta.Annotations)
 		assert.Contains(tt, objectMeta.Annotations, IstioPodAnnotationName)
 		assert.Equal(tt, "holdApplicationUntilProxyStarts: true\nproxyMetadata:\n  OUTPUT_CERTS: /etc/istio-output-certs\n", toYaml(tt, IstioPodAnnotationValue))
+	})
+
+	t.Run("it=does not override when pods annotation contained a value", func(tt *testing.T) {
+		existingAnnotation := map[string]interface{}{
+			"holdApplicationUntilProxyStarts": false,
+			"proxyMetadata": map[string]interface{}{
+				"OUTPUT_CERTS": "/etc/istio-output-certs",
+			},
+		}
+		objectMeta := &metav1.ObjectMeta{
+			Annotations: map[string]string{
+				IstioPodAnnotationName: toYaml(tt, existingAnnotation),
+			},
+		}
+		SetMetadata(objectMeta)
+		assert.NotNil(tt, objectMeta.Annotations)
+		assert.Contains(tt, objectMeta.Annotations, IstioPodAnnotationName)
+		assert.Equal(tt, "holdApplicationUntilProxyStarts: false\nproxyMetadata:\n  OUTPUT_CERTS: /etc/istio-output-certs\n", toYaml(tt, IstioPodAnnotationValue))
 	})
 
 }

--- a/pkg/istio-aux/util_test.go
+++ b/pkg/istio-aux/util_test.go
@@ -1,0 +1,48 @@
+package istioaux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetAnnotation(t *testing.T) {
+
+	t.Run("it=sets the default annotation when no annotations on pod", func(tt *testing.T) {
+		objectMeta := &metav1.ObjectMeta{}
+		SetMetadata(objectMeta)
+		assert.NotNil(tt, objectMeta.Annotations)
+		assert.Contains(tt, objectMeta.Annotations, IstioPodAnnotationName)
+		assert.Equal(tt, "holdApplicationUntilProxyStarts: true\n", toYaml(tt, IstioPodAnnotationValue))
+	})
+
+	t.Run("it=merges with existing annotation", func(tt *testing.T) {
+
+		existingAnnotation := map[string]interface{}{
+			"proxyMetadata": map[string]interface{}{
+				"OUTPUT_CERTS": "/etc/istio-output-certs",
+			},
+		}
+
+		objectMeta := &metav1.ObjectMeta{
+			Annotations: map[string]string{
+				IstioPodAnnotationName: toYaml(tt, existingAnnotation),
+			},
+		}
+
+		SetMetadata(objectMeta)
+
+		assert.NotNil(tt, objectMeta.Annotations)
+		assert.Contains(tt, objectMeta.Annotations, IstioPodAnnotationName)
+		assert.Equal(tt, "holdApplicationUntilProxyStarts: true\nproxyMetadata:\n  OUTPUT_CERTS: /etc/istio-output-certs\n", toYaml(tt, IstioPodAnnotationValue))
+	})
+
+}
+
+func toYaml(t *testing.T, data map[string]interface{}) string {
+	bs, err := yaml.Marshal(&data)
+	assert.Nil(t, err)
+	return string(bs)
+}


### PR DESCRIPTION
This PR fixes the annotation handling:

- Uses the correct `meta.Annotations` instead of `meta.Labels` in `setAnnotation`.
- Handles merging with an existing value, if an annotation existed.