### PR TITLE
Fix annotation handling - use local annotation accumulator

### DIFF
--- a/pkg/istio-aux/util_test.go
+++ b/pkg/istio-aux/util_test.go
@@ -24,6 +24,12 @@ func TestSetAnnotation(t *testing.T) {
 				"OUTPUT_CERTS": "/etc/istio-output-certs",
 			},
 		}
+		expectedAnnotation := map[string]interface{}{
+			"holdApplicationUntilProxyStarts": true,
+			"proxyMetadata": map[string]interface{}{
+				"OUTPUT_CERTS": "/etc/istio-output-certs",
+			},
+		}
 		objectMeta := &metav1.ObjectMeta{
 			Annotations: map[string]string{
 				IstioPodAnnotationName: toYaml(tt, existingAnnotation),
@@ -32,7 +38,7 @@ func TestSetAnnotation(t *testing.T) {
 		SetMetadata(objectMeta)
 		assert.NotNil(tt, objectMeta.Annotations)
 		assert.Contains(tt, objectMeta.Annotations, IstioPodAnnotationName)
-		assert.Equal(tt, "holdApplicationUntilProxyStarts: true\nproxyMetadata:\n  OUTPUT_CERTS: /etc/istio-output-certs\n", toYaml(tt, IstioPodAnnotationValue))
+		assert.Equal(tt, "holdApplicationUntilProxyStarts: true\nproxyMetadata:\n  OUTPUT_CERTS: /etc/istio-output-certs\n", toYaml(tt, expectedAnnotation))
 	})
 
 	t.Run("it=does not override when pods annotation contained a value", func(tt *testing.T) {
@@ -50,7 +56,7 @@ func TestSetAnnotation(t *testing.T) {
 		SetMetadata(objectMeta)
 		assert.NotNil(tt, objectMeta.Annotations)
 		assert.Contains(tt, objectMeta.Annotations, IstioPodAnnotationName)
-		assert.Equal(tt, "holdApplicationUntilProxyStarts: false\nproxyMetadata:\n  OUTPUT_CERTS: /etc/istio-output-certs\n", toYaml(tt, IstioPodAnnotationValue))
+		assert.Equal(tt, "holdApplicationUntilProxyStarts: false\nproxyMetadata:\n  OUTPUT_CERTS: /etc/istio-output-certs\n", toYaml(tt, existingAnnotation))
 	})
 
 }

--- a/pkg/istio-aux/webhook.go
+++ b/pkg/istio-aux/webhook.go
@@ -22,7 +22,6 @@ package istioaux
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,9 +56,9 @@ func (a *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 		  values: ["enabled"]
 	*/
 
-	logger.WithName("webhook").Info(fmt.Sprintf("processing pod %s", pod.ObjectMeta.Name))
+	logger.WithName("webhook").Info("processing", "pod-generate-name", pod.GenerateName, "pod-name", pod.ObjectMeta.Name)
 	SetMetadata(&pod.ObjectMeta)
-	logger.WithName("webhook").Info(fmt.Sprintf("pod %s processed", pod.ObjectMeta.Name))
+	logger.WithName("webhook").Info("processed", "pod-generate-name", pod.GenerateName, "pod-name", pod.ObjectMeta.Name)
 
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {


### PR DESCRIPTION
Hi @akirillov,

The previous PR that fixed overwriting of the existing `proxy.istio.io/config` values (https://github.com/datastrophic/istio-aux/pull/1) introduced a _hindenbug_. The description is below. This PR fixes the newly introduced problem.

Because of the change from a `const` label value to a `variable map`, the _hindenbug_ was introduced. This would surface itself in the following way:

- Pod `a` in the namespace `a` launched with annotation `proxy.istio.io/config`, where yaml data contains key `a`, `b`, `c`.
- Pod `b` in the namespace `a` launched with annotation `proxy.istio.io/config`, where yaml data contains key `a`.

Pod `b` would inherit annotations of pod `a` because the global `IstioPodAnnotationValue` behaved as an accumulator.

The correct behavior should be:

- Pod `a` in the namespace `a` launched with annotation `proxy.istio.io/config`, where yaml data contains key `a`, `b`, `c`. Launched pod contains `a`, `b`, and `c`.
- Pod `b` in the namespace `a` launched with annotation `proxy.istio.io/config`, where yaml data contains key `a`. Launched pod contains `a` only.

This pull request fixes this problem.